### PR TITLE
Remove non-ascii characters in slides python code

### DIFF
--- a/slides.html
+++ b/slides.html
@@ -559,7 +559,7 @@
           # Your program waits for the user to hit enter
           name = raw_input("Please enter your name: ")
 
-          # … then continues to this line
+          # ... then continues to this line
           print("Hello " + name)
           ```
       </script>
@@ -838,7 +838,7 @@
         ```python
         >>> chapters = open('./exercises/llc-chapters.csv')
         >>> print(chapters.read())
-        # … lots of file data …
+        # ... lots of file data ...
         >>> chapters.close()
         # When you're done with a file it's a good idea to close it
         ```
@@ -927,7 +927,7 @@
         ```python
         line = chapters.next()
         # Execute your code block
-        # …
+        # ...
         # Go back to get the next value and repeat until there are no more values
         ```
 


### PR DESCRIPTION
New comers might want to copy and paste code that is part of the slides. If that code contains non-ascii characters, like the *…* character, it might not run properly on their computer. For instance, if I copy the content of the python source on slice #26 in PyCharm:

```python
# Assign the raw_input value to a variable
# Your program waits for the user to hit enter
name = raw_input("Please enter your name: ")

# … then continues to this line
print("Hello " + name)
```

it will fail with the following error:

```
  File "/Users/hidden/Downloads/llc-intro-to-python-master/exercises/ex1_hello_world.py", line 5
SyntaxError: Non-ASCII character '\xe2' in file /Users/hidden/Downloads/llc-intro-to-python-master/exercises/ex1_hello_world.py on line 5, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details

Process finished with exit code 1
```

In order to minimize potential confusion, it would be better to make python source code in the slides runnable. Removing those non-ascii characters will achieve this goal.