### PR TITLE
Avoid using [[]] to indicate replacement

### DIFF
--- a/exercises/ex4_chapter_lead_finder.py
+++ b/exercises/ex4_chapter_lead_finder.py
@@ -9,4 +9,4 @@ import csv
 
     # Compare the 'City' in the row with your city
 
-        # Print "Thank you [[Chapter Lead(s)]]!"
+        # Print a thank you message to your chapter lead(s)

--- a/exercises/fr/ex4_responsable_de_chapitre.py
+++ b/exercises/fr/ex4_responsable_de_chapitre.py
@@ -10,4 +10,4 @@ import csv
 
     # comparez le champ 'City' à votre ville
 
-        # Imprimez "Merci [[les responsables du chapitre]]! dans la console"
+        # Imprimez un message qui remerci les responsables du chapitre dans la console

--- a/slides-fr.html
+++ b/slides-fr.html
@@ -1094,7 +1094,7 @@
 
             # comparez le champ 'City' à votre ville
 
-                # Imprimez "Merci [[les responsables du chapitre]]! dans la console"
+                # Imprimez un message qui remerci les responsables du chapitre dans la console
         ```
       </script>
     </section>

--- a/slides.html
+++ b/slides.html
@@ -1091,7 +1091,7 @@
         
             # Compare the 'City' in the row with your city
         
-                # Print "Thank you [[Chapter Lead(s)]]!"
+                # Print a thank you message to your chapter lead(s)
         ```
       </script>
     </section>


### PR DESCRIPTION
Learners found [[Chapter Lead(s)]] as a way to indicate replacement with their chapter leads confusing when presented shortly after learning the format `chapter['Chapter Lead(s)']`.  Rewrite to avoid this form.