### PR TITLE
Add python 3 instructions, couple other tweaks

### DIFF
--- a/slides-fr.html
+++ b/slides-fr.html
@@ -531,16 +531,22 @@
         
         À la place d'afficher simplement 'Hello World' sur l'écran, allons un peu plus loin et utilisons Python pour saluer tout le monde!
       
-        Essayez d'utiliser la fonction `raw_input()`. De cette façon, les données entrées par un utilisateur vous seront **retournées**.
+        Essayez d'utiliser a fonction `raw_input()` en Python 2 (ou `input` si vous avez installé Python 3). De cette façon, les données entrées par un utilisateur vous seront **retournées**.
         
-        1. Donnez à `raw_input()` un message demandant une information précise à l'utilisateur
+        1. Donnez à `raw_input()` (ou `input()`) un message demandant une information précise à l'utilisateur
         1. L'utilisateur entre quelque chose et appuie sur la touche **entrée** 
         1. Peu importe ce que l'utilisateur entre, cette information vous est **retournée**.
   
         Essayez-le dans la console:
 
+        Python 2
         ```python
         >>> raw_input("Quel est votre nom?")
+        ```
+        
+        Python 3
+        ```python
+        >>> input("Quel est votre nom?")
         ```
       </script>
     </section>
@@ -561,11 +567,21 @@
 
         1. Ajoutez ce petit programme/code à votre ficher.
 
+          Python 2
           ```python
           # Assignez la valeur de raw_input a la variable
           # Your program waits for the user to hit enter
           nom = raw_input("S.V.P entrez votre nom: ")
+          ```
 
+          Python 3
+          ```python
+          # Assignez la valeur de input a la variable
+          # Your program waits for the user to hit enter
+          nom = input("S.V.P entrez votre nom: ")
+          ```
+        
+          ```python
           # ... Puis continuez sur cette ligne
           print("Bonjour " + nom)
           ```
@@ -664,9 +680,19 @@
 
         ```python
         # file: ex2_conseil_meteo.py
-        # -*- coding: utf-8 -*-
+        ```
+        
+        Python 2
+        ```python
         meteo = raw_input("Quel temps fait-il? (froid, pluvieux, etc.)")
+        ```
 
+        Python 3
+        ```python
+        meteo = input("Quel temps fait-il? (froid, pluvieux, etc.)")
+        ```
+        
+        ```python
         if meteo == "froid":
             print("Mets un chandail!")
         elif meteo == "pluvieux":

--- a/slides-fr.html
+++ b/slides-fr.html
@@ -920,14 +920,10 @@
       <script type="text/template">
         ## L'arrière-scène des boucles `for`
 
-        Si vous explorez la variable `chapters` dans votre console, vous remarquerez peut-être qu'elle possède une méthode nommée `.next()`. Elle effectue la même chose que la méthode `.readline()`. 
-
-        La boucle `for` fonctionne avec différents regroupements de données; la seule chose qu'elle demande en retour est la présence de la méthode `.next()`.
-
-        En dessous des couvertes, elle effectue quelque chose de similaire à:
+        En dessous des couvertes, la boucle `for` effectue quelque chose de similaire à:
 
         ```python
-        line = chapters.next()
+        line = next(chapters)
         # exécution de votre code dans la boucle
         # ...
         # traitement de la donnée suivante jusqu'à ce qu'il n'y ait plus de valeur
@@ -1011,7 +1007,7 @@
         Nous pouvons maintenant obtenir une ligne à la fois:
 
         ```
-        >>>     chapter = chapters_data.next()
+        >>>     chapter = next(chapters_data)
         >>>     print(chapter)
         {'City': 'Vancouver', 'Chapter Lead(s)': 'Meghan', 'Province': 'BC'}
         >>>     type(chapter)

--- a/slides-fr.html
+++ b/slides-fr.html
@@ -907,8 +907,8 @@
 
         ```python
         >>> with open('./exercises/llc-chapters.csv') as chapters:
-        >>> for line in chapters:
-        ...     print(line)
+        >>>     for line in chapters:
+        ...         print(line)
         ...
         ```
 

--- a/slides.html
+++ b/slides.html
@@ -925,14 +925,10 @@
       <script type="text/template">
         ## `for` loop behind the scenes
 
-        If you play around with the `chapters` variable in your console, you might notice that it has a `.next()` function which does the same thing as `.readline()`
-
-        `for` can work with many different collections of data, all it&rsquo;s looking for is that `.next()` function.
-
-        Behind the scenes, it&rsquo;s doing something roughly like
+        Behind the scenes, the for loop is doing something roughly like:
 
         ```python
-        line = chapters.next()
+        line = next(chapters)
         # Execute your code block
         # ...
         # Go back to get the next value and repeat until there are no more values
@@ -1012,7 +1008,7 @@
         Now, we can pull out one row at a time.
 
         ```
-        >>>     chapter = chapters_data.next()
+        >>>     chapter = next(chapters_data)
         >>>     print(chapter)
         {'City': 'Vancouver', 'Chapter Lead(s)': 'Meghan', 'Province': 'BC'}
         >>>     type(chapter)

--- a/slides.html
+++ b/slides.html
@@ -528,12 +528,20 @@
 
         Instead of just a 'Hello World' message on the screen, take it one step further and have Python say hello to anyone!
 
-        Try using the `raw_input()` function. This will get the data inputed by a user and **returns** that value back to you.
-
-        1. Give `raw_input()` a message to let the user know what information is being requested using this syntax (note the quotes):
+        The function `raw_input` in Python 2 (or `input` if you have installed Python 3) will get the data input by the user and **return* the value back to you.
+        
+        1. Give input function a message to let the user know what information is being requested using this syntax (note the quotes):
+        
+          Python 2
           ```python
           >>> raw_input("What's your name?")
-          ``` 
+          ```
+          
+          Python 3
+          ```python
+          >>> input("What's your name?")
+          ```
+        
         1. The user types a response and hits the **enter** key
         1. Whatever the user types is **returned** to you.
 
@@ -563,10 +571,21 @@
         
           Reminder, anything after the `#` symbol is just a comment.
 
+          Python 2: 
           ```python
           # Assign the raw_input value to a variable
           # Your program waits for the user to hit enter
           name = raw_input("Please enter your name: ")
+
+          # ... then continues to this line
+          print("Hello " + name)
+          ```
+
+          Python 3:
+          ```python
+          # Assign the input value to a variable
+          # Your program waits for the user to hit enter
+          name = input("Please enter your name: ")
 
           # ... then continues to this line
           print("Hello " + name)
@@ -666,8 +685,19 @@
 
         ```python
         # file: ex2_weather_advice.py
+        ```
+        
+        ```python
+        # Python 2:
         weather = raw_input("What is the weather? (cold, raining, etc.)")
+        ```
+        
+        ```python
+        # Python 3:
+        weather = input("What is the weather? (cold, raining, etc.)")
+        ```
 
+        ```python
         if weather == "cold":
             print("Wear a sweater!")
         elif weather == "raining":

--- a/slides.html
+++ b/slides.html
@@ -910,8 +910,8 @@
 
         ```python
         >>> with open('./exercises/llc-chapters.csv') as chapters:
-        >>> for line in chapters:
-        ...     print(line)
+        >>>     for line in chapters:
+        ...         print(line)
         ...
         ```
         


### PR DESCRIPTION
One fix and a couple of python 3 tweaks!

Fix:
* Added missing indentation for a for loop

Added updates for python 3: the docs say 2.7 is required, but it seems like sometimes folks show up with python 3 (and 2.7 will be deprecated eventually!) so makes sense to add the alternatives for python 3 to the slides:
- `raw_input` vs. `input`
- `next(foo)` vs. `foo.next()` (the latter being discouraged anyway!)

(It might make sense to have a slide about how to know if you're running python 2 or 3 also but I didn't feel confident enough in my french to add a slide to both!)

@christinatruong