### PR TITLE
Highlight Python 2 vs 3 difference for integer division

### DIFF
--- a/slides-fr.html
+++ b/slides-fr.html
@@ -260,11 +260,33 @@
 
         ```
         >>> 1 / 2
-        0
+        ???
         ```
-        Pourquoi `1 / 2 = 0`? Nous y reviendrons...
+        
       </script>
     </section>
+
+    <section class="slide" data-markdown>
+        <script type="text/template">
+          ## Python peut faire des maths - division
+  
+          Python 2
+          ```
+          >>> 1 / 2
+          0
+          ```
+  
+          Python 3
+          ```python
+          >>> 1 / 2
+          0.5
+          >>> 1 // 2
+          0
+          ```
+  
+          Pourquoi `1 / 2 = 0` en Python 2? Nous y reviendrons...
+        </script>
+      </section>
 
     <section class="slide" data-markdown>
       <script type="text/template">
@@ -397,7 +419,7 @@
         ```
         
         <br>
-        Vous vous souvenez de l'exemple `1/2 = 0` ? quand Python divise deux **integers**, il &laquo;arrondit&raquo; le résultat au plus petit nombre entier (dans ce cas 0).
+        Vous vous souvenez de l'exemple `1/2 = 0` ? quand Python 2 divise deux **integers**, il &laquo;arrondit&raquo; le résultat au plus petit nombre entier (dans ce cas 0).
 
         Les **types** «integer» sont des nombres entiers (sans décimales), donc si vous voulez être plus précis, `float()` peut être utilisé pour inclure des décimales.
         ```

--- a/slides.html
+++ b/slides.html
@@ -255,13 +255,34 @@
         >>> 2 * 15
         30
         ```
+       
+        ```
+        >>> 1 / 2
+        ???
+        ```
+      </script>
+    </div>
+    </section>
 
+    <section class="slide" data-markdown>
+      <script type="text/template">
+        ## Python can do math - Division
+
+        Python 2
         ```
         >>> 1 / 2
         0
         ```
-        Why is `1 / 2 = 0`? We&rsquo;ll come back to that.
 
+        Python 3
+        ```python
+        >>> 1 / 2
+        0.5
+        >>> 1 // 2
+        0
+        ```
+
+        Why is `1 / 2 = 0` in Python 2? We&rsquo;ll come back to that.
       </script>
     </section>
 
@@ -398,7 +419,7 @@
         ```
 
         <br>
-        Remember the `1/2 = 0` example? When Python divides two integers, it rounds the result down to the nearest integer (in this case 0).
+        Remember the `1/2 = 0` example? When Python 2 divides two integers, it rounds the result down to the nearest integer (in this case 0).
 
         Integer **types** are whole numbers (no decimals), so to be more precise, `float()` can be used to include decimals.
         ```


### PR DESCRIPTION
All of the other relevant Python 3 differences are called out and I know this has confused learners in the past with the way it's presented. I split the math slide into 2, with a 2nd one calling out the division differences, and added a reference to Python 2 in the later slide that refers to it. I updated the French as well.